### PR TITLE
Add accountdir flag

### DIFF
--- a/_build_local.sh
+++ b/_build_local.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+echo "============================================================"
+echo " Byte Dehydrated fork Development Build"
+echo " - Will build package from a temp Git branch"
+echo " - Will NOT tag the build"
+echo " - Will NOT push anything"
+echo "============================================================"
+
+ARCH="amd64"
+DIST="xenial"
+BUILDAREA="${BUILDAREA:-/tmp/dehydrated-build}"
+BUILDPATH="${BUILDAREA}-${DIST}"
+
+CURRENT_BRANCH=`git rev-parse --abbrev-ref HEAD`
+if [ -z "$BRANCH" ]; then
+    BRANCH="$CURRENT_BRANCH"
+fi
+
+
+export VERSION=$(date "+%Y%m%d.%H%M%S")
+
+git checkout $BRANCH
+TEMPBRANCH="$BRANCH-build-$DIST-$VERSION"
+git checkout -b $TEMPBRANCH
+
+echo "Generating changelog changelog"
+gbp dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch $TEMPBRANCH --release --commit
+
+
+echo "Building package for $DIST"
+mkdir -p $BUILDPATH
+gbp buildpackage --git-pbuilder --git-export-dir=$BUILDPATH --git-dist=$DIST --git-arch=$ARCH \
+--git-debian-branch=$TEMPBRANCH --git-ignore-new
+
+echo
+echo "*************************************************************"
+echo "Package built succesfully!"
+echo "--> ${BUILDPATH}/dehydrated-${VERSION}_all.deb"
+echo
+echo "Checking out original branch ..."
+git checkout $BRANCH
+
+if [ -z "${KEEP_TEMPBRANCH}" ]; then
+    echo "Removing temp Git branch "$TEMPBRANCH" ... (to avoid this set KEEP_TEMPBRANCH env variable)"
+    git branch -D $TEMPBRANCH
+    echo ""
+    echo "You can clear things up by"
+    echo "------------------------------------------------------------"
+    echo "rm -rf ${BUILDPATH}"
+else
+    echo "You can clear things up by"
+    echo "------------------------------------------------------------"
+    echo "git branch -D ${TEMPBRANCH}"
+    echo "rm -rf ${BUILDPATH}"
+fi

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+set -e 
+
+ARCH="amd64"
+DIST="xenial"
+BUILDAREA="/tmp/dehydrated-build"
+BRANCH="debian"
+
+if [ "$(git rev-parse --abbrev-ref HEAD)" != $BRANCH ]; then
+    echo "You are not on the $BRANCH branch, aborting"
+    /bin/false
+fi;
+
+export VERSION=$(date "+%Y%m%d.%H%M%S")
+
+echo "Generating changelog changelog"
+gbp dch --debian-tag="%(version)s" --new-version=$VERSION --debian-branch $BRANCH --release --commit
+
+
+echo "Building package for $DIST"
+
+git checkout $BRANCH
+TEMPBRANCH="$BRANCH-build-$DIST-$VERSION"
+git checkout -b $TEMPBRANCH
+
+mkdir -p $BUILDAREA-$DIST
+gbp buildpackage --git-pbuilder --git-export-dir=$BUILDAREA-$DIST --git-dist=$DIST --git-arch=$ARCH \
+--git-debian-branch=$TEMPBRANCH --git-ignore-new
+
+git checkout $BRANCH
+git branch -D $TEMPBRANCH
+
+echo
+echo "*************************************************************"
+echo
+
+echo "Creating tag $VERSION"
+git tag $VERSION
+
+echo "Now push the commit with the version update and the tag: git push; git push --tags"

--- a/dehydrated
+++ b/dehydrated
@@ -69,6 +69,7 @@ store_configvars() {
   __RENEW_DAYS="${RENEW_DAYS}"
   __IP_VERSION="${IP_VERSION}"
   __CREATE_DIRS="${CREATE_DIRS}"
+  __ACCOUNTDIR="${ACCOUNTDIR}"
 }
 
 reset_configvars() {
@@ -84,6 +85,7 @@ reset_configvars() {
   RENEW_DAYS="${__RENEW_DAYS}"
   IP_VERSION="${__IP_VERSION}"
   CREATE_DIRS="${__CREATE_DIRS}"
+  ACCOUNTDIR="${__ACCOUNTDIR}"
 }
 
 hookscript_bricker_hook() {
@@ -234,6 +236,7 @@ load_config() {
 
   # Create new account directory or symlink to account directory from old CA
   CAHASH="$(echo "${CA}" | urlbase64)"
+  [[ -n "${PARAM_ACCOUNTDIR:-}" ]] && ACCOUNTDIR="${PARAM_ACCOUNTDIR}"
   [[ -z "${ACCOUNTDIR}" ]] && ACCOUNTDIR="${BASEDIR}/accounts"
   if [[ ! -e "${ACCOUNTDIR}/${CAHASH}" ]]; then
     OLDCAHASH="$(echo "${OLDCA}" | urlbase64)"
@@ -1653,6 +1656,18 @@ main() {
           PARAM_DOMAIN="${1}"
         else
           PARAM_DOMAIN="${PARAM_DOMAIN} ${1}"
+         fi
+        ;;
+
+      # PARAM_Usage: --account-dir path/to/directory 
+      # PARAM_Description: Use specified directory instead of /data/web/.dehydrated/accounts/
+      --account-dir)
+        shift 1
+        check_parameters "${1:-}"
+        if [[ -z "${PARAM_ACCOUNTDIR:-}" ]]; then
+          PARAM_ACCOUNTDIR="${1}"
+        else
+          PARAM_ACCOUNTDIR="${PARAM_ACCOUNTDIR} ${1}"
          fi
         ;;
 


### PR DESCRIPTION
On new hypernodes, we use dehydrated to generate Let's Encrypt certificated for the domain <appname>.hypernode.io. To do this, the root user has to accept the Let's Encrypt terms, which also accepts them on behalf of the app user. This is not right, so we add an --account-dir flag so the root user can have its own account with Let's Encrypt and the app user can choose whether to use their service separately