### PR TITLE
push debian branch not head

### DIFF
--- a/mark-release.sh
+++ b/mark-release.sh
@@ -141,7 +141,7 @@ if $COMMIT; then
 
     if $PUSH; then
         log "pushing changes to origin ..."
-        git push origin HEAD
+        git push origin debian
         if $TAG; then
             git push origin $VERSION
         fi


### PR DESCRIPTION
to fix
```
+ git push origin HEAD
error: unable to push to unqualified destination: HEAD
The destination refspec neither matches an existing ref on the remote nor
begins with refs/, and we are unable to guess a prefix based on the source ref.
error: failed to push some refs to 'git@github.com:ByteInternet/dehydrated.git'
```